### PR TITLE
fix command escaping

### DIFF
--- a/core/command.go
+++ b/core/command.go
@@ -90,7 +90,7 @@ func (c Command) String() string {
 			cmdStr.WriteString(",")
 		}
 
-		cmdStr.WriteString(fmt.Sprintf("%s=%s", key, escape(val)))
+		cmdStr.WriteString(fmt.Sprintf("%s=%s", key, escapeProperty(val)))
 	}
 
 	cmdStr.WriteString(cmdString)
@@ -98,15 +98,24 @@ func (c Command) String() string {
 	return cmdStr.String()
 }
 
+var escaperData = strings.NewReplacer(
+	"%", "%25",
+	"\r", "%0D",
+	"\n", "%0A",
+)
+
 func escapeData(s string) string {
-	return strings.NewReplacer("\r", "%0D", "\n", "%0A").Replace(s)
+	return escaperData.Replace(s)
 }
 
-func escape(s string) string {
-	return strings.NewReplacer(
-		"\r", "%0D",
-		"\n", "%0A",
-		"]", "%5D",
-		";", "%3B",
-	).Replace(s)
+var escaperProperty = strings.NewReplacer(
+	"%", "%25",
+	"\r", "%0D",
+	"\n", "%0A",
+	":", "%3A",
+	",", "%2C",
+)
+
+func escapeProperty(s string) string {
+	return escaperProperty.Replace(s)
 }

--- a/core/command_test.go
+++ b/core/command_test.go
@@ -27,6 +27,32 @@ func TestCommand(t *testing.T) {
 			mes:  "/path/to/dir",
 			want: "::add-path::/path/to/dir",
 		},
+
+		// test cases for escaping
+		{
+			cmd:  "some-command",
+			p:    nil,
+			mes:  "percent % percent % cr \r cr \r lf \n lf \n",
+			want: "::some-command::percent %25 percent %25 cr %0D cr %0D lf %0A lf %0A",
+		},
+		{
+			cmd:  "some-command",
+			p:    nil,
+			mes:  "%25 %25 %0D %0D %0A %0A",
+			want: "::some-command::%2525 %2525 %250D %250D %250A %250A",
+		},
+		{
+			cmd:  "some-command",
+			p:    NewCommandProperties("name", "percent % percent % cr \r cr \r lf \n lf \n colon : colon : comma , comma ,"),
+			mes:  "",
+			want: "::some-command name=percent %25 percent %25 cr %0D cr %0D lf %0A lf %0A colon %3A colon %3A comma %2C comma %2C::",
+		},
+		{
+			cmd:  "some-command",
+			p:    NewCommandProperties("name", "%25 %25 %0D %0D %0A %0A %3A %3A %2C %2C"),
+			mes:  "",
+			want: "::some-command name=%2525 %2525 %250D %250D %250A %250A %253A %253A %252C %252C::",
+		},
 	}
 	for _, tt := range tests {
 		if got := NewCommand(tt.cmd, tt.p, tt.mes).String(); got != tt.want {


### PR DESCRIPTION
backport of https://github.com/actions/toolkit/pull/302

related with https://github.com/actions/toolkit/issues/301

> The toolkit uses the new command syntax (`::command::`), yet the old escaping rules (for `##[command]`).